### PR TITLE
fix(ci): use npm ci instead of npm install to prevent dirty lockfile

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Build frontend
         run: |
           cd web/admin-ui
-          npm install
+          npm ci
           npm run build
 
       - name: golangci-lint
@@ -94,7 +94,7 @@ jobs:
       - name: Build frontend
         run: |
           cd web/admin-ui
-          npm install
+          npm ci
           npm run build
 
       - name: Run tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Build frontend
         run: |
           cd web/admin-ui
-          npm install
+          npm ci
           npm run build
 
       - name: Run GoReleaser


### PR DESCRIPTION
npm install can modify package-lock.json when node_modules cache is restored, causing goreleaser to reject the release due to dirty git state. npm ci is designed for CI environments — it strictly follows the lockfile and never modifies it.