### PR TITLE
ci: bump Node.js to 24 (latest LTS) in workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache-dependency-path: 'web/admin-ui/package-lock.json'
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - name: Build frontend
@@ -83,7 +83,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache-dependency-path: 'web/admin-ui/package-lock.json'
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - name: Install GoReleaser

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache-dependency-path: 'web/admin-ui/package-lock.json'
           cache: 'npm'
 


### PR DESCRIPTION
ci: bump Node.js to 24 (latest LTS) in workflows